### PR TITLE
Disable homepage hiring banner

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -94,4 +94,4 @@ defaultContentLanguageInSubdir = false
 
   [params.jobs]
     show_no_open_positions = false
-    show_hiring_banner = true
+    show_hiring_banner = false


### PR DESCRIPTION
## Summary
- Set `show_hiring_banner` to `false` in `config.toml`
- Hides the "We're hiring! Join our team" banner on the homepage

## Test plan
- [x] Build the Hugo site locally
- [x] Confirm the homepage no longer shows the jobs banner
- [x] Confirm `/jobs/` page still works as expected


Made with [Cursor](https://cursor.com)