### PR TITLE
Fix AurumTool link URL

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -174,7 +174,7 @@ AurumTools — die kostenlose All-in-one-App für Goldschmiede.
 Mit praktischen Helfern wie Legierungsrechnern, Edelstein-Tools und Atelier-Utilities macht sie den Alltag im Studio einfacher und unterstützt traditionelle Handwerkskunst.
 <br>
 <br>
-Mehr Informationen auf <a href="https://www.kaddick.de/aurumtools/" target="_blank">www.kaddick.de/aurumtools</a>.
+Mehr Informationen auf <a href="https://www.kaddick.de/aurumtool/" target="_blank">www.kaddick.de/aurumtool</a>.
 '''
 
 [customersVVSTitle]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -170,7 +170,7 @@ Feel the power of your workbench!
 AurumTools — the free all-in-one app for goldsmiths. With handy helpers like alloy calculators, gemstone tools and studio utilities, it simplifies daily workflows in the workshop and supports traditional craftsmanship.
 <br>
 <br>
-More information at <a href="https://www.kaddick.de/aurumtools/" target="_blank">www.kaddick.de/aurumtools</a>.
+More information at <a href="https://www.kaddick.de/aurumtool/" target="_blank">www.kaddick.de/aurumtool</a>.
 '''
 
 [customersVVSTitle]


### PR DESCRIPTION
## Summary
- Update the AurumTools project link from `/aurumtools/` to `/aurumtool/` in EN and DE copy

## Test plan
- [x] Confirm the AurumTools work description links to https://www.kaddick.de/aurumtool/ in English
- [x] Confirm the same link in German
- [x] Open the URL and verify it loads


Made with [Cursor](https://cursor.com)