### PR TITLE
Remove skewed bar behind contact portraits

### DIFF
--- a/themes/raditian-free-hugo-theme-adjusted/static/css/custom.css
+++ b/themes/raditian-free-hugo-theme-adjusted/static/css/custom.css
@@ -540,21 +540,7 @@ body {
     align-items: center;
 }
 
-.person::before {
-    content: '';
-    position: absolute;
-    left: 50px;
-    top: 0;
-    width: 70px;
-    height: 100%;
-    z-index: 1;
-    background-color: #edf1f4;
-    -webkit-transform: skew(-13deg);
-    transform: skew(-13deg);
-}
-
 .person > img {
-    z-index: 2;
     width: auto;
     height: 130px;
 }
@@ -2943,10 +2929,6 @@ button.work-stats__item {
 .person .name-and-title a.name:hover,
 .person .name-and-title a.name:focus-visible {
     color: #96143c;
-}
-
-.person--plain::before {
-    content: none;
 }
 
 .person--plain > img {


### PR DESCRIPTION
## Summary
- Removes the decorative skewed gray bar (`::before`) behind Julian and Stefan on the contact page.
- Portraits now sit on the white page background with no extra shape behind them.

## Test plan
- [ ] Open `/contact/` and confirm there is no gray parallelogram behind the two portraits.
- [ ] Open `/de/contact/` and confirm the same.
- [ ] Check that names, titles, and LinkedIn links still line up next to the photos.


Made with [Cursor](https://cursor.com)